### PR TITLE
Feat: Make core components overridable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,9 +50,10 @@ export default {
 
         // We may in future want to extend the component list
         if(options && options.hasOwnProperty('plugins')) {
-            components = Object.assign({
+            components = {
+                ...components,
                 ...options.plugins
-            }, components)
+            }
         }
 
         // Setup a new instance of the config, this will later


### PR DESCRIPTION
Minor: Refactor component Object.assign call (we use object spread syntax to
clone the core components anyway, so we may as well use it for the
composition process too).

Major: swap order that they are composed, so that
`options.plugins` can actually override a core component.

**Potentially breaking change**, but It means people can override the default widgets, which is super handy.